### PR TITLE
Added NSPhotoLibraryAddUsageDescription for iOS

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -33,8 +33,14 @@
       </feature>
     </config-file>
 
+    <preference name="PHOTOLIBRARY_ADD_USAGE_DESCRIPTION" default="This app needs write-access to photo library"/>
+    <config-file target="*-Info.plist" parent="NSPhotoLibraryAddUsageDescription">
+      <string>$PHOTOLIBRARY_ADD_USAGE_DESCRIPTION</string>
+    </config-file>
+
+    <preference name="PHOTOLIBRARY_USAGE_DESCRIPTION" default="This app needs read/write-access photo library access"/>
     <config-file target="*-Info.plist" parent="NSPhotoLibraryUsageDescription">
-      <string>Save images into gallery</string>
+      <string>$PHOTOLIBRARY_USAGE_DESCRIPTION</string>
     </config-file>
 
     <header-file src="src/ios/Base64ToGallery.h"/>


### PR DESCRIPTION
Merging some iOS permissions, based on [cordova-plugin-ios-camera-permissions](https://github.com/Cordobo/cordova-plugin-ios-camera-permissions/blob/master/plugin.xml), and adding NSPhotoLibraryAddUsageDescription (required in iOS 11).